### PR TITLE
Taskruns from configmap

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -124,6 +124,10 @@ func CreateTransceiver(taskname string) serving.Service {
 										Value: taskname,
 									},
 									{
+										Name:  "TASKRUN_CONFIGMAP",
+										Value: taskname,
+									},
+									{
 										Name: "NAMESPACE",
 										ValueFrom: &corev1.EnvVarSource{
 											FieldRef: &corev1.ObjectFieldSelector{

--- a/config/service.yaml
+++ b/config/service.yaml
@@ -13,7 +13,9 @@ spec:
             image: github.com/triggermesh/aktion/cmd/transceiver
             env:
               - name: TASK_NAME
-                value: "knative-test"
+                value: ""
+              - name: TASKRUN_CONFIGMAP
+                value: ""  
               - name: NAMESPACE
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
If transceiver's `TASKRUN_CONFIGMAP` env variable set, try to read configmap and parse its content into taskrun objects. Example usage: [service](https://github.com/triggermesh/knative-upgrade-task/blob/master/cron.yaml), [taskruns](https://github.com/triggermesh/knative-upgrade-task/blob/master/taskruns.yaml)
