### PR TITLE
Fix usage of environment variables

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -279,6 +279,14 @@ func extractActions(action *model.Action, config *model.Configuration) []Task {
 			Value: v,
 		}
 
+		for i := range task.Args {
+			if strings.Contains(task.Args[i], "$" + k) {
+				task.Args[i] = strings.ReplaceAll(task.Args[i], "$" + k, "$(" + k + ")")
+			} else if strings.Contains(task.Args[i], "${" + k + "}") {
+				task.Args[i] = strings.ReplaceAll(task.Args[i], "${" + k + "}", "$(" + k + ")")
+			}
+		}
+
 		task.Envs = append(task.Envs, env)
 	}
 


### PR DESCRIPTION
Upon documenting the improvements made to the `uses` parameter for Github actions, I observed that environment variables being passed on the command line weren't being expanded as expected. This was due to the way Kubernetes handles pod creation, by expecting environment variables to be wrapped in `$()` instead of the more traditional expansion of `$ENV_NAME` or `${ENV_NAME}`.